### PR TITLE
Handle empty personal number

### DIFF
--- a/src/BankID.php
+++ b/src/BankID.php
@@ -103,10 +103,13 @@ class BankID
     {
         try {
             $parameters = [
-                'personalNumber' => $personalNumber,
                 'endUserIp' => $ip,
                 'userVisibleData' => base64_encode($userVisibleData),
             ];
+
+            if (!empty($personalNumber)) {
+                $parameters['personalNumber'] = $personalNumber;
+            }
 
             if (!empty($userNonVisibleData)) {
                 $parameters['userNonVisibleData'] = base64_encode($userNonVisibleData);

--- a/src/BankID.php
+++ b/src/BankID.php
@@ -68,12 +68,17 @@ class BankID
      */
     public function authenticate($personalNumber, $ip)
     {
+        $payload['endUserIp'] = $ip;
+
+        if (!empty($personalNumber)) {
+            $payload['personalNumber'] = $personalNumber;
+        }
+
         try {
+
+
             $httpResponse = $this->httpClient->post('auth', [
-                RequestOptions::JSON => [
-                    'personalNumber' => $personalNumber,
-                    'endUserIp' => $ip,
-                ],
+                RequestOptions::JSON => $payload,
             ]);
         } catch (RequestException $e) {
             return $this->requestExceptionToBankIDResponse($e);

--- a/src/BankIDResponse.php
+++ b/src/BankIDResponse.php
@@ -202,4 +202,12 @@ class BankIDResponse
     {
         return $this->body['hintCode'] ?? null;
     }
+
+    /**
+     * @return null|string
+     */
+    public function getAutoStartToken()
+    {
+        return $this->body['autoStartToken'] ?? null;
+    }
 }


### PR DESCRIPTION
This PR makes it possible to use an empty personal number when authenticating and signing and adds a getter for the autoStartToken.
This makes it possible to implement autostart of the client bankID-app without requiring the end-user to supply a personal number.
See: [Section 3.1](https://www.bankid.com/assets/bankid/rp/bankid-relying-party-guidelines-v3.2.4.pdf)

A have done some rudimentary testing and all seems to be ok. 